### PR TITLE
Add direct JuMP integration bypassing expensive initialize

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,8 @@ authors = ["odow <o.dowson@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
+JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["odow <o.dowson@gmail.com>"]
 version = "0.1.0"
 
 [deps]
-Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/README.md
+++ b/README.md
@@ -36,9 +36,23 @@ Pkg.add("https://github.com/odow/SymbolicAD.jl)
 
 ## Use with JuMP
 
+There are two ways to use SymbolicAD with JuMP.
+
+First, you can use `SymbolicAD.Optimizer`:
 ```julia
 using JuMP
 import Ipopt
 import SymbolicAD
 model = Model(() -> SymbolicAD.Optimizer(Ipopt.Optimizer))
 ```
+
+Second, you can set an `SymbolicAD.optimizer_hook`:
+```julia
+using JuMP
+import Ipopt
+import SymbolicAD
+model = Model(Ipopt.Optimizer)
+set_optimizer_hook(model, SymbolicAD.optimizer_hook)
+```
+
+In general, the `SymbolicAD.optimizer_hook` approach should be faster.

--- a/src/SymbolicAD.jl
+++ b/src/SymbolicAD.jl
@@ -1,6 +1,7 @@
 module SymbolicAD
 
 import Base.Meta: isexpr
+import JuMP
 import MathOptInterface
 import SparseArrays
 import Symbolics

--- a/src/nonlinear_oracle.jl
+++ b/src/nonlinear_oracle.jl
@@ -156,11 +156,7 @@ mutable struct _NonlinearOracle{B} <: MOI.AbstractNLPEvaluator
     eval_constraint_timer::Float64
     eval_constraint_jacobian_timer::Float64
     eval_hessian_lagrangian_timer::Float64
-    function _NonlinearOracle(
-        backend::B,
-        objective,
-        constraints,
-    ) where {B}
+    function _NonlinearOracle(backend::B, objective, constraints) where {B}
         return new{B}(
             backend,
             objective,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,8 @@ function run_unit_benchmark(model::JuMP.Model)
     @info "Constructing oracles"
 
     @time d = JuMP.NLPEvaluator(model)
-    @time nlp_block = SymbolicAD.nlp_block_data(d)
+    @time nlp_block =
+        SymbolicAD._nlp_block_data(d; backend = SymbolicAD.DefaultBackend())
     oracle = nlp_block.evaluator
 
     @info "MOI.initialize"
@@ -159,7 +160,7 @@ function run_solution_benchmark(model::JuMP.Model)
 
     serial_model = Ipopt.Optimizer()
     MOI.copy_to(serial_model, model)
-    serial_nlp_block = SymbolicAD.nlp_block_data(
+    serial_nlp_block = SymbolicAD._nlp_block_data(
         JuMP.NLPEvaluator(model);
         backend = SymbolicAD.DefaultBackend(),
     )
@@ -175,7 +176,7 @@ function run_solution_benchmark(model::JuMP.Model)
 
     threaded_model = Ipopt.Optimizer()
     MOI.copy_to(threaded_model, model)
-    threaded_nlp_block = SymbolicAD.nlp_block_data(
+    threaded_nlp_block = SymbolicAD._nlp_block_data(
         JuMP.NLPEvaluator(model);
         backend = SymbolicAD.ThreadedBackend(),
     )
@@ -309,6 +310,38 @@ function test_optimizer_case5_pjm()
     set_optimizer(model, Ipopt.Optimizer)
     optimize!(model)
     Test.@test isapprox(objective_value(model), symbolic_obj, atol = 1e-6)
+    return
+end
+
+function test_optimizer_case5_pjm_optimize_hook()
+    model = power_model("pglib_opf_case5_pjm.m")
+    set_optimizer(model, Ipopt.Optimizer)
+    set_optimize_hook(model, SymbolicAD.optimize_hook)
+    optimize!(model)
+    symbolic_obj = objective_value(model)
+    set_optimize_hook(model, nothing)
+    optimize!(model)
+    Test.@test isapprox(objective_value(model), symbolic_obj, atol = 1e-6)
+    return
+end
+
+"""
+    test_optimize_hook()
+
+This model is chosen to have a number of unique features that cover the range of
+node types in JuMP's nonlinear expression data structure.
+"""
+function test_optimize_hook()
+    model = Model(Ipopt.Optimizer)
+    @variable(model, 0 <= x <= 2π, start = π)
+    @NLexpression(model, y, sin(x))
+    @NLparameter(model, p == 1)
+    @NLconstraint(model, sqrt(y + 2) <= p + 1)
+    @NLobjective(model, Min, p * y)
+    set_optimize_hook(model, SymbolicAD.optimize_hook)
+    optimize!(model)
+    Test.@test isapprox(objective_value(model), -1; atol = 1e-6)
+    Test.@test isapprox(value(x), 1.5 * π; atol = 1e-6)
     return
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,12 +19,15 @@ function runtests()
     return
 end
 
-function run_unit_benchmark(model::JuMP.Model)
+function run_unit_benchmark(model::JuMP.Model; direct_model::Bool = false)
     @info "Constructing oracles"
 
     @time d = JuMP.NLPEvaluator(model)
-    @time nlp_block =
+    @time nlp_block = if direct_model
+        SymbolicAD._nlp_block_data(model; backend = SymbolicAD.DefaultBackend())
+    else
         SymbolicAD._nlp_block_data(d; backend = SymbolicAD.DefaultBackend())
+    end
     oracle = nlp_block.evaluator
 
     @info "MOI.initialize"
@@ -253,7 +256,8 @@ end
 
 function test_case5_pjm_unit()
     model = power_model("pglib_opf_case5_pjm.m")
-    run_unit_benchmark(model)
+    run_unit_benchmark(model; direct_model = false)
+    run_unit_benchmark(model; direct_model = true)
     return
 end
 


### PR DESCRIPTION
This PR adds an optimize hook that directly replaces JuMP's AD system. 

<s>It's currently a little wasteful in that it goes JuMP -> Expr -> _Function. Now that it's working, I'll try and skip the intermediary Expr step.</s> It's actually useful because it allows us to expand subexpressions first.

I haven't attempted to incorporate user-defined functions yet.