### PR TITLE
Add tools to validate the derivatives produced by JuMP

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,9 +5,11 @@ version = "0.1.0"
 
 [deps]
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Ipopt = "1"
@@ -21,7 +23,6 @@ julia = "1.6"
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 PowerModels = "c36e90e8-916a-50a6-bd94-075b64ef4655"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Ipopt", "JuMP", "PowerModels", "Test"]
+test = ["Ipopt", "JuMP", "PowerModels"]

--- a/src/SymbolicAD.jl
+++ b/src/SymbolicAD.jl
@@ -2,13 +2,15 @@ module SymbolicAD
 
 import Base.Meta: isexpr
 import JuMP
+import LinearAlgebra
 import MathOptInterface
 import SparseArrays
 import Symbolics
+import Test
 
 const MOI = MathOptInterface
 
 include("nonlinear_oracle.jl")
 include("MOI_wrapper.jl")
-
+include("jump_test_utilities.jl")
 end

--- a/src/jump_test_utilities.jl
+++ b/src/jump_test_utilities.jl
@@ -1,0 +1,234 @@
+"""
+    run_unit_benchmark(
+        model::JuMP.Model;
+        direct_model::Bool,
+        atol::Float64 = 1e-10,
+    )
+
+Given a JuMP Model `model`, run a series of unit tests. This can be helpful to
+test differences between JuMP and SymbolicAD (using an atol of `atol`), and also
+to check relative performance.
+
+If `direct_model`, build the SymbolicAD backend directly from JuMP's NLP
+datastructures. If `direct_model == false`, build from `MOI.objective_expr` and
+`MOI.constraint_expr`.
+"""
+function run_unit_benchmark(
+    model::JuMP.Model;
+    direct_model::Bool,
+    atol::Float64 = 1e-10,
+    rtol::Float64 = 0.0,
+)
+    @info "Constructing oracles"
+
+    @time d = JuMP.NLPEvaluator(model)
+    @time nlp_block = if direct_model
+        _nlp_block_data(model; backend = DefaultBackend())
+    else
+        _nlp_block_data(d; backend = DefaultBackend())
+    end
+    oracle = nlp_block.evaluator
+
+    @info "MOI.initialize"
+
+    @time MOI.initialize(d, [:Grad, :Jac, :Hess])
+    @time MOI.initialize(oracle, [:Grad, :Jac, :Hess])
+
+    # !!! note
+    #     When trying to micro-benchmark this, be careful, because JuMP caches
+    #     the last x and avoids redundant computation. Therefore calling
+    #     MOI.eval_constraint multiple times with the same x will be optimistic
+    #     compared with calling it with different x
+
+    x = map(JuMP.all_variables(model)) do xi
+        lb = JuMP.has_lower_bound(xi) ? JuMP.lower_bound(xi) : -1e6
+        ub = JuMP.has_upper_bound(xi) ? JuMP.upper_bound(xi) : 1e6
+        return lb + (ub - lb) * rand()
+    end
+
+    if d.has_nlobj
+        # MOI.eval_objective
+
+        @info "MOI.eval_objective"
+
+        @time MOI.eval_objective(d, x)
+        @time MOI.eval_objective(d, x)
+        @time MOI.eval_objective(oracle, x)
+        @time MOI.eval_objective(oracle, x)
+
+        d_eval_objective = MOI.eval_objective(d, x)
+        oracle_eval_objective = MOI.eval_objective(oracle, x)
+        Test.@test isapprox(
+            d_eval_objective,
+            oracle_eval_objective;
+            atol = atol,
+            rtol = rtol,
+        )
+        println("Error = ", d_eval_objective - oracle_eval_objective)
+
+        # MOI.eval_objective_gradient
+
+        @info "MOI.eval_objective_gradient"
+
+        f = zeros(length(x))
+        f1 = zeros(length(x))
+
+        @time MOI.eval_objective_gradient(d, f1, x)
+        @time MOI.eval_objective_gradient(d, f1, x)
+        @time MOI.eval_objective_gradient(oracle, f, x)
+        @time MOI.eval_objective_gradient(oracle, f, x)
+
+        Test.@test isapprox(f, f1; atol = atol, rtol = rtol)
+        println("Error = ", maximum(abs.(f .- f1)))
+    end
+
+    # MOI.eval_constraint
+
+    @info "MOI.eval_constraint"
+
+    g = zeros(length(oracle.constraints))
+    g1 = zeros(length(oracle.constraints))
+
+    @time MOI.eval_constraint(d, g1, x)
+    @time MOI.eval_constraint(d, g1, x)
+    @time MOI.eval_constraint(oracle, g, x)
+    @time MOI.eval_constraint(oracle, g, x)
+
+    Test.@test isapprox(g, g1; atol = atol, rtol = rtol)
+    println("Error = ", maximum(abs.(g .- g1)))
+
+    # MOI.jacobian_structure
+
+    @info "MOI.jacobian_structure"
+
+    @time J1 = MOI.jacobian_structure(d)
+    @time J = MOI.jacobian_structure(oracle)
+
+    p, p1 = sortperm(J), sortperm(J1)
+    Test.@test J[p] == J1[p1]
+
+    # MOI.eval_constraint_jacobian
+
+    @info "MOI.eval_constraint_jacobian"
+
+    J_nz, J_nz_1 = zeros(length(J)), zeros(length(J1))
+
+    @time MOI.eval_constraint_jacobian(d, J_nz_1, x)
+    @time MOI.eval_constraint_jacobian(d, J_nz_1, x)
+    @time MOI.eval_constraint_jacobian(oracle, J_nz, x)
+    @time MOI.eval_constraint_jacobian(oracle, J_nz, x)
+
+    Test.@test isapprox(J_nz[p], J_nz_1[p1]; atol = atol, rtol = rtol)
+    println("Error = ", LinearAlgebra.norm(J_nz[p] .- J_nz_1[p1]))
+
+    # MOI.hessian_lagrangian_structure
+
+    @info "MOI.hessian_lagrangian_structure"
+
+    @time H1 = MOI.hessian_lagrangian_structure(d)
+    @time H = MOI.hessian_lagrangian_structure(oracle)
+
+    # MOI.eval_hessian_lagrangian
+
+    @info "MOI.eval_hessian_lagrangian"
+
+    μ, H_nz, H_nz_1 = rand(length(g)), zeros(length(H)), zeros(length(H1))
+    σ = rand()
+    @time MOI.eval_hessian_lagrangian(d, H_nz_1, x, σ, μ)
+    @time MOI.eval_hessian_lagrangian(d, H_nz_1, x, σ, μ)
+    @time MOI.eval_hessian_lagrangian(oracle, H_nz, x, σ, μ)
+    @time MOI.eval_hessian_lagrangian(oracle, H_nz, x, σ, μ)
+
+    # For the Hessian, we won't compute identical sparsity patterns due to
+    # duplicates, etc. What we need to do is check the full sparse matrix.
+
+    function _to_sparse(IJ, V)
+        I, J = [i for (i, _) in IJ], [j for (_, j) in IJ]
+        n = max(maximum(I), maximum(J))
+        return SparseArrays.sparse(I, J, V, n, n)
+    end
+
+    d_sparse = _to_sparse(H, H_nz)
+    oracle_sparse = _to_sparse(H1, H_nz_1)
+    Test.@test isapprox(d_sparse, oracle_sparse; atol = atol, rtol = rtol)
+    println("Error = ", LinearAlgebra.norm(d_sparse - oracle_sparse))
+    return
+end
+
+"""
+    run_solution_benchmark(model::JuMP.Model, optimizer)
+
+Given a JuMP Model `model`, solve the problem using JuMP's built-in AD, as well
+as the `DefaultBackend` and `ThreadedBackend` of SymbolicAD and check that they
+find the same solutions.
+
+`optimizer` must be something that can be passed to `MOI.instantiate`.
+"""
+function run_solution_benchmark(model::JuMP.Model, optimizer)
+    @info "Solving with JuMP"
+
+    jump_model = MOI.instantiate(optimizer)
+    MOI.copy_to(jump_model, model)
+    MOI.optimize!(jump_model)
+    jump_solution = MOI.get(
+        jump_model,
+        MOI.VariablePrimal(),
+        MOI.get(jump_model, MOI.ListOfVariableIndices()),
+    )
+    jump_nlp_block = MOI.get(model, MOI.NLPBlock())
+
+    @info "Solving with serial SymbolicAD"
+
+    serial_model = MOI.instantiate(optimizer)
+    MOI.copy_to(serial_model, model)
+    serial_nlp_block = _nlp_block_data(
+        JuMP.NLPEvaluator(model);
+        backend = DefaultBackend(),
+    )
+    MOI.set(serial_model, MOI.NLPBlock(), serial_nlp_block)
+    MOI.optimize!(serial_model)
+    serial_solution = MOI.get(
+        serial_model,
+        MOI.VariablePrimal(),
+        MOI.get(serial_model, MOI.ListOfVariableIndices()),
+    )
+
+    @info "Solving with threaded SymbolicAD"
+
+    threaded_model = MOI.instantiate(optimizer)
+    MOI.copy_to(threaded_model, model)
+    threaded_nlp_block = _nlp_block_data(
+        JuMP.NLPEvaluator(model);
+        backend = ThreadedBackend(),
+    )
+    MOI.set(threaded_model, MOI.NLPBlock(), threaded_nlp_block)
+    MOI.optimize!(threaded_model)
+    threaded_solution = MOI.get(
+        threaded_model,
+        MOI.VariablePrimal(),
+        MOI.get(threaded_model, MOI.ListOfVariableIndices()),
+    )
+
+    @info "Validating solutions"
+
+    Test.@test isapprox(jump_solution, serial_solution; atol = 1e-6)
+    Test.@test isapprox(jump_solution, threaded_solution; atol = 1e-6)
+
+    @info "Timing statistics"
+
+    println("JuMP timing statistics")
+    println(" - ", jump_nlp_block.evaluator.eval_constraint_timer)
+    println(" - ", jump_nlp_block.evaluator.eval_constraint_jacobian_timer)
+    println(" - ", jump_nlp_block.evaluator.eval_hessian_lagrangian_timer)
+
+    println("Serial SymbolicAD timing statistics")
+    println(" - ", serial_nlp_block.evaluator.eval_constraint_timer)
+    println(" - ", serial_nlp_block.evaluator.eval_constraint_jacobian_timer)
+    println(" - ", serial_nlp_block.evaluator.eval_hessian_lagrangian_timer)
+
+    println("Threaded SymbolicAD timing statistics")
+    println(" - ", threaded_nlp_block.evaluator.eval_constraint_timer)
+    println(" - ", threaded_nlp_block.evaluator.eval_constraint_jacobian_timer)
+    println(" - ", threaded_nlp_block.evaluator.eval_hessian_lagrangian_timer)
+    return
+end

--- a/test/data/.gitignore
+++ b/test/data/.gitignore
@@ -1,0 +1,2 @@
+pglib_opf_case1888_rte.m
+pglib_opf_case2853_sdet.m

--- a/test/perf/benchmark.jl
+++ b/test/perf/benchmark.jl
@@ -5,7 +5,7 @@ import SymbolicAD
 
 function power_model(case::String)
     pm = PowerModels.instantiate_model(
-        joinpath(@__DIR__, "data", case),
+        joinpath(dirname(@__DIR__), "data", case),
         PowerModels.ACPPowerModel,
         PowerModels.build_opf,
     )

--- a/test/perf/validate.jl
+++ b/test/perf/validate.jl
@@ -1,3 +1,4 @@
+import Ipopt
 import PowerModels
 import SymbolicAD
 
@@ -12,6 +13,7 @@ end
 
 model = power_model("pglib_opf_case2853_sdet.m")
 SymbolicAD.run_unit_benchmark(model; direct_model = true, atol = 1e-6)
+SymbolicAD.run_solution_benchmark(model, Ipopt.Optimizer; atol = 1.0)
 
-model = power_model("pglib_opf_case5_pjm.m")
-SymbolicAD.run_unit_benchmark(model; direct_model = true, atol = 1e-11)
+# model = power_model("pglib_opf_case5_pjm.m")
+# SymbolicAD.run_unit_benchmark(model; direct_model = true, atol = 1e-11)

--- a/test/perf/validate.jl
+++ b/test/perf/validate.jl
@@ -1,0 +1,17 @@
+import PowerModels
+import SymbolicAD
+
+function power_model(case::String)
+    pm = PowerModels.instantiate_model(
+        joinpath(dirname(@__DIR__), "data", case),
+        PowerModels.ACPPowerModel,
+        PowerModels.build_opf,
+    )
+    return pm.model
+end
+
+model = power_model("pglib_opf_case2853_sdet.m")
+SymbolicAD.run_unit_benchmark(model; direct_model = true, atol = 1e-6)
+
+model = power_model("pglib_opf_case5_pjm.m")
+SymbolicAD.run_unit_benchmark(model; direct_model = true, atol = 1e-11)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,6 @@ using JuMP
 
 import Ipopt
 import PowerModels
-import SparseArrays
 import SymbolicAD
 import Test
 
@@ -19,210 +18,14 @@ function runtests()
     return
 end
 
-function run_unit_benchmark(model::JuMP.Model; direct_model::Bool = false)
-    @info "Constructing oracles"
-
-    @time d = JuMP.NLPEvaluator(model)
-    @time nlp_block = if direct_model
-        SymbolicAD._nlp_block_data(model; backend = SymbolicAD.DefaultBackend())
-    else
-        SymbolicAD._nlp_block_data(d; backend = SymbolicAD.DefaultBackend())
-    end
-    oracle = nlp_block.evaluator
-
-    @info "MOI.initialize"
-
-    @time MOI.initialize(d, [:Grad, :Jac, :Hess])
-    @time MOI.initialize(oracle, [:Grad, :Jac, :Hess])
-
-    # !!! note
-    #     When trying to micro-benchmark this, be careful, because JuMP caches
-    #     the last x and avoids redundant computation. Therefore calling
-    #     MOI.eval_constraint multiple times with the same x will be optimistic
-    #     compared with calling it with different x
-
-    x = rand(JuMP.num_variables(model))
-
-    if d.has_nlobj
-        # MOI.eval_objective
-
-        @info "MOI.eval_objective"
-
-        @time MOI.eval_objective(d, x)
-        @time MOI.eval_objective(d, x)
-        @time MOI.eval_objective(oracle, x)
-        @time MOI.eval_objective(oracle, x)
-
-        Test.@test isapprox(
-            MOI.eval_objective(d, x),
-            MOI.eval_objective(oracle, x);
-            atol = 1e-10,
-        )
-
-        # MOI.eval_objective_gradient
-
-        @info "MOI.eval_objective_gradient"
-
-        f = zeros(length(x))
-        f1 = zeros(length(x))
-
-        @time MOI.eval_objective_gradient(d, f1, x)
-        @time MOI.eval_objective_gradient(d, f1, x)
-        @time MOI.eval_objective_gradient(oracle, f, x)
-        @time MOI.eval_objective_gradient(oracle, f, x)
-
-        Test.@test isapprox(f, f1; atol = 1e-10)
-    end
-
-    # MOI.eval_constraint
-
-    @info "MOI.eval_constraint"
-
-    g = zeros(length(oracle.constraints))
-    g1 = zeros(length(oracle.constraints))
-
-    @time MOI.eval_constraint(d, g1, x)
-    @time MOI.eval_constraint(d, g1, x)
-    @time MOI.eval_constraint(oracle, g, x)
-    @time MOI.eval_constraint(oracle, g, x)
-
-    Test.@test isapprox(g, g1; atol = 1e-10)
-
-    # MOI.jacobian_structure
-
-    @info "MOI.jacobian_structure"
-
-    @time J1 = MOI.jacobian_structure(d)
-    @time J = MOI.jacobian_structure(oracle)
-
-    p, p1 = sortperm(J), sortperm(J1)
-    Test.@test J[p] == J1[p1]
-
-    # MOI.eval_constraint_jacobian
-
-    @info "MOI.eval_constraint_jacobian"
-
-    J_nz, J_nz_1 = zeros(length(J)), zeros(length(J1))
-
-    @time MOI.eval_constraint_jacobian(d, J_nz_1, x)
-    @time MOI.eval_constraint_jacobian(d, J_nz_1, x)
-    @time MOI.eval_constraint_jacobian(oracle, J_nz, x)
-    @time MOI.eval_constraint_jacobian(oracle, J_nz, x)
-
-    Test.@test isapprox(J_nz[p], J_nz_1[p1]; atol = 1e-10)
-
-    # MOI.hessian_lagrangian_structure
-
-    @info "MOI.hessian_lagrangian_structure"
-
-    @time H1 = MOI.hessian_lagrangian_structure(d)
-    @time H = MOI.hessian_lagrangian_structure(oracle)
-
-    # MOI.eval_hessian_lagrangian
-
-    @info "MOI.eval_hessian_lagrangian"
-
-    μ, H_nz, H_nz_1 = rand(length(g)), zeros(length(H)), zeros(length(H1))
-
-    @time MOI.eval_hessian_lagrangian(d, H_nz_1, x, 1.0, μ)
-    @time MOI.eval_hessian_lagrangian(d, H_nz_1, x, 1.0, μ)
-    @time MOI.eval_hessian_lagrangian(oracle, H_nz, x, 1.0, μ)
-    @time MOI.eval_hessian_lagrangian(oracle, H_nz, x, 1.0, μ)
-
-    # For the Hessian, we won't compute identical sparsity patterns due to
-    # duplicates, etc. What we need to do is check the full sparse matrix.
-
-    function _to_sparse(IJ, V)
-        I, J = [i for (i, _) in IJ], [j for (_, j) in IJ]
-        n = max(maximum(I), maximum(J))
-        return SparseArrays.sparse(I, J, V, n, n)
-    end
-
-    Test.@test isapprox(
-        _to_sparse(H, H_nz),
-        _to_sparse(H1, H_nz_1);
-        atol = 1e-6,
-    )
-    return
-end
-
-function run_solution_benchmark(model::JuMP.Model)
-    @info "Solving with JuMP"
-
-    jump_model = Ipopt.Optimizer()
-    MOI.copy_to(jump_model, model)
-    MOI.optimize!(jump_model)
-    jump_solution = MOI.get(
-        jump_model,
-        MOI.VariablePrimal(),
-        MOI.get(jump_model, MOI.ListOfVariableIndices()),
-    )
-    jump_nlp_block = MOI.get(model, MOI.NLPBlock())
-
-    @info "Solving with serial SymbolicAD"
-
-    serial_model = Ipopt.Optimizer()
-    MOI.copy_to(serial_model, model)
-    serial_nlp_block = SymbolicAD._nlp_block_data(
-        JuMP.NLPEvaluator(model);
-        backend = SymbolicAD.DefaultBackend(),
-    )
-    MOI.set(serial_model, MOI.NLPBlock(), serial_nlp_block)
-    MOI.optimize!(serial_model)
-    serial_solution = MOI.get(
-        serial_model,
-        MOI.VariablePrimal(),
-        MOI.get(serial_model, MOI.ListOfVariableIndices()),
-    )
-
-    @info "Solving with threaded SymbolicAD"
-
-    threaded_model = Ipopt.Optimizer()
-    MOI.copy_to(threaded_model, model)
-    threaded_nlp_block = SymbolicAD._nlp_block_data(
-        JuMP.NLPEvaluator(model);
-        backend = SymbolicAD.ThreadedBackend(),
-    )
-    MOI.set(threaded_model, MOI.NLPBlock(), threaded_nlp_block)
-    MOI.optimize!(threaded_model)
-    threaded_solution = MOI.get(
-        threaded_model,
-        MOI.VariablePrimal(),
-        MOI.get(threaded_model, MOI.ListOfVariableIndices()),
-    )
-
-    @info "Validating solutions"
-
-    Test.@test isapprox(jump_solution, serial_solution; atol = 1e-6)
-    Test.@test isapprox(jump_solution, threaded_solution; atol = 1e-6)
-
-    @info "Timing statistics"
-
-    println("JuMP timing statistics")
-    println(" - ", jump_nlp_block.evaluator.eval_constraint_timer)
-    println(" - ", jump_nlp_block.evaluator.eval_constraint_jacobian_timer)
-    println(" - ", jump_nlp_block.evaluator.eval_hessian_lagrangian_timer)
-
-    println("Serial SymbolicAD timing statistics")
-    println(" - ", serial_nlp_block.evaluator.eval_constraint_timer)
-    println(" - ", serial_nlp_block.evaluator.eval_constraint_jacobian_timer)
-    println(" - ", serial_nlp_block.evaluator.eval_hessian_lagrangian_timer)
-
-    println("Threaded SymbolicAD timing statistics")
-    println(" - ", threaded_nlp_block.evaluator.eval_constraint_timer)
-    println(" - ", threaded_nlp_block.evaluator.eval_constraint_jacobian_timer)
-    println(" - ", threaded_nlp_block.evaluator.eval_hessian_lagrangian_timer)
-    return
-end
-
 """
-    run_clnlbeam_benchmark(; N::Int)
+    _run_clnlbeam_benchmark(; N::Int)
 
 This is a good benchmark for the perils of Symbolic AD, because it has a
 nonlinear objective function, and the nonlinear objective function has thousands
 of terms.
 """
-function run_clnlbeam_benchmark(; N::Int)
+function _run_clnlbeam_benchmark(; N::Int)
     h = 1 / N
     model = Model()
     @variable(model, -1 <= t[1:(N+1)] <= 1)
@@ -240,8 +43,9 @@ function run_clnlbeam_benchmark(; N::Int)
         @NLconstraint(model, x[i+1] - x[i] == h / 2 * (sin(t[i+1]) + sin(t[i])))
         @constraint(model, t[i+1] - t[i] == h / 2 * (u[i+1] - u[i]))
     end
-    run_unit_benchmark(model)
-    run_solution_benchmark(model)
+    # Different rtol because the points we pick can be quite bad
+    SymbolicAD.run_unit_benchmark(model; direct_model = true, rtol = 1e-6)
+    SymbolicAD.run_solution_benchmark(model, Ipopt.Optimizer)
     return
 end
 
@@ -256,20 +60,20 @@ end
 
 function test_case5_pjm_unit()
     model = power_model("pglib_opf_case5_pjm.m")
-    run_unit_benchmark(model; direct_model = false)
-    run_unit_benchmark(model; direct_model = true)
+    SymbolicAD.run_unit_benchmark(model; direct_model = false)
+    SymbolicAD.run_unit_benchmark(model; direct_model = true)
     return
 end
 
 function test_case5_pjm_solution()
     model = power_model("pglib_opf_case5_pjm.m")
-    run_solution_benchmark(model)
+    SymbolicAD.run_solution_benchmark(model, Ipopt.Optimizer)
     return
 end
 
 function test_clnlbeam()
-    run_clnlbeam_benchmark(; N = 10)
-    run_clnlbeam_benchmark(; N = 100)
+    _run_clnlbeam_benchmark(; N = 10)
+    _run_clnlbeam_benchmark(; N = 100)
     return
 end
 


### PR DESCRIPTION
The failing `case2853_sdet` in @ccoffrin's experiments has errors on the order of 1e-10, which may explain the error.