### PR TITLE
Fix subexpressions in expressions

### DIFF
--- a/src/nonlinear_oracle.jl
+++ b/src/nonlinear_oracle.jl
@@ -536,8 +536,9 @@ function MOI.Nonlinear.Evaluator(
 )
     variable_order =
         Dict(x.value => i for (i, x) in enumerate(ordered_variables))
-    subexpressions = map(model.expressions) do expr
-        return _to_expr(model, expr, variable_order, Expr[])::Expr
+    subexpressions = Vector{Expr}()
+    for sub in model.expressions
+        push!(subexpressions, _to_expr(model, sub, variable_order, subexpressions))
     end
     objective = nothing
     if model.objective !== nothing

--- a/src/nonlinear_oracle.jl
+++ b/src/nonlinear_oracle.jl
@@ -536,9 +536,9 @@ function MOI.Nonlinear.Evaluator(
 )
     variable_order =
         Dict(x.value => i for (i, x) in enumerate(ordered_variables))
-    subexpressions = Vector{Expr}()
-    for sub in model.expressions
-        push!(subexpressions, _to_expr(model, sub, variable_order, subexpressions))
+    subexpressions = Vector{Expr}(undef, length(model.expressions))
+    for (i, sub) in enumerate(model.expressions)
+        subexpressions[i] = _to_expr(model, sub, variable_order, subexpressions)
     end
     objective = nothing
     if model.objective !== nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -297,6 +297,21 @@ function test_user_defined_functions()
     return
 end
 
+function test_nested_subexpressions()
+    model = Model(Ipopt.Optimizer)
+    @variable(model, 0.5 <= x <= 1.0)
+    @NLexpression(model, my_expr1, x - 1)
+    @NLexpression(model, my_expr2, my_expr1^2)
+    @NLobjective(model, Min, my_expr2)
+    optimize!(
+        model;
+        _differentiation_backend = MathOptSymbolicAD.DefaultBackend(),
+    )
+    Test.@test termination_status(model) == LOCALLY_SOLVED
+    Test.@test ≈(value(x), 1.0; atol = 1e-3)
+    return
+end
+
 end  # module
 
 RunTests.runtests()


### PR DESCRIPTION
There might be a bug that I hit when having subexpressions in expressions. `subexpressions` in `_to_expr` points to the empty `Expr[]` argument. I think this should fix that.