### PR TITLE
Relicense under LANL's standard BSD-3 license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,22 +1,38 @@
-MathOptSymbolicAD.jl is licensed under the MIT License:
+Copyright (c) 2022, Triad National Security, LLC
+Copyright (c) 2022, Oscar Dowson and contributors
+All rights reserved.
 
-> Copyright (c) 2022: Oscar Dowson
->
-> Permission is hereby granted, free of charge, to any person obtaining
-> a copy of this software and associated documentation files (the
-> "Software"), to deal in the Software without restriction, including
-> without limitation the rights to use, copy, modify, merge, publish,
-> distribute, sublicense, and/or sell copies of the Software, and to
-> permit persons to whom the Software is furnished to do so, subject to
-> the following conditions:
->
-> The above copyright notice and this permission notice shall be
-> included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-> LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-> OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-> WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+This software was produced under U.S. Government contract 89233218CNA000001 for
+Los Alamos National Laboratory (LANL), which is operated by Triad National
+Security, LLC for the U.S. Department of Energy/National Nuclear Security
+Administration. All rights in the program are reserved by Triad National
+Security, LLC, and the U.S. Department of Energy/National Nuclear Security
+Administration. The Government is granted for itself and others acting on its
+behalf a nonexclusive, paid-up, irrevocable worldwide license in this material
+to reproduce, prepare derivative works, distribute copies to the public, perform
+publicly and display publicly, and to permit others to do so.
+
+This program is open source under the BSD-3 License.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -70,3 +70,8 @@ large number of unique constraints in the model (which would require a lot of
 expressions to be symbolically differentiated), or if the nonlinear functions
 contain a large number of nonlinear terms (which would make the symbolic
 derivative expensive to compute).
+
+## License
+
+This software is provided under a BSD license as part of the Grid Optimization
+Competition Solvers project, C19076. See LICENSE.md.

--- a/src/MathOptSymbolicAD.jl
+++ b/src/MathOptSymbolicAD.jl
@@ -1,7 +1,8 @@
-# Copyright (c) 2022: Oscar Dowson, and contributors
+# Copyright (c) 2022, Oscar Dowson and contributors
+# Copyright (c) 2022, Triad National Security, LLC
 #
-# Use of this source code is governed by an MIT-style license that can be found
-# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
 
 module MathOptSymbolicAD
 

--- a/src/ThreadedBackend.jl
+++ b/src/ThreadedBackend.jl
@@ -1,7 +1,8 @@
-# Copyright (c) 2022: Oscar Dowson, and contributors
+# Copyright (c) 2022, Oscar Dowson and contributors
+# Copyright (c) 2022, Triad National Security, LLC
 #
-# Use of this source code is governed by an MIT-style license that can be found
-# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
 
 struct _ConstraintOffset
     index::Int

--- a/src/nonlinear_oracle.jl
+++ b/src/nonlinear_oracle.jl
@@ -1,7 +1,8 @@
-# Copyright (c) 2022: Oscar Dowson, and contributors
+# Copyright (c) 2022, Oscar Dowson and contributors
+# Copyright (c) 2022, Triad National Security, LLC
 #
-# Use of this source code is governed by an MIT-style license that can be found
-# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
 
 abstract type _AbstractFunction end
 

--- a/test/perf/benchmark.jl
+++ b/test/perf/benchmark.jl
@@ -1,7 +1,8 @@
-# Copyright (c) 2022: Oscar Dowson, and contributors
+# Copyright (c) 2022, Oscar Dowson and contributors
+# Copyright (c) 2022, Triad National Security, LLC
 #
-# Use of this source code is governed by an MIT-style license that can be found
-# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
 
 import Ipopt
 import JuMP

--- a/test/perf/validate.jl
+++ b/test/perf/validate.jl
@@ -1,7 +1,8 @@
-# Copyright (c) 2022: Oscar Dowson, and contributors
+# Copyright (c) 2022, Oscar Dowson and contributors
+# Copyright (c) 2022, Triad National Security, LLC
 #
-# Use of this source code is governed by an MIT-style license that can be found
-# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
 
 import Ipopt
 import PowerModels

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
-# Copyright (c) 2022: Oscar Dowson, and contributors
+# Copyright (c) 2022, Oscar Dowson and contributors
+# Copyright (c) 2022, Triad National Security, LLC
 #
-# Use of this source code is governed by an MIT-style license that can be found
-# in the LICENSE.md file or at https://opensource.org/licenses/MIT.
+# Use of this source code is governed by a BSD-style license that can be found
+# in the LICENSE.md file.
 
 module RunTests
 


### PR DESCRIPTION
@michel2323 you have one contribution: https://github.com/lanl-ansi/MathOptSymbolicAD.jl/commit/824b08454f461e8bd18c119790bb8b1991551ab5

Are you okay relicensing under BSD? We've moved this repo to the `lanl-ansi` account.

Closes #32 